### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/loopback/Dockerfile
+++ b/docker/loopback/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /app
 
 # Update Linux Packages
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install mysql-client -y
+RUN apt-get install default-mysql-client -y
 
 # Run update and Strongloop install
 RUN npm install -g npm


### PR DESCRIPTION
Substituição do pacote mysql-client, depreciado na versão buster do debian, por default-mysql-client. Assim será instalado o mariadb-client-10.3 que poderá ser iniciado pelo comando mysql.