### PR TITLE
Ajuste no nome do pacote de drivers mysql-client

### DIFF
--- a/docker/loopback/Dockerfile
+++ b/docker/loopback/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /app
 
 # Update Linux Packages
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install mysql-client -y
+RUN apt-get install default-mysql-client -y
 
 # Run update and Strongloop install
 RUN npm install -g npm


### PR DESCRIPTION
Para a distribuição Debian da versão mais atual dp Docker a instalação do pacote de drivers mysql-client teve o nome alterado. Para evitar o erro da execução renomeado o pacote para "default-mysql-client".